### PR TITLE
Fix duplicate menus in GradientEditorItem

### DIFF
--- a/pyqtgraph/graphicsItems/GradientEditorItem.py
+++ b/pyqtgraph/graphicsItems/GradientEditorItem.py
@@ -874,6 +874,7 @@ class Tick(QtGui.QGraphicsWidget):  ## NOTE: Making this a subclass of GraphicsO
         else:
             self.view().tickClicked(self, ev)
             ##remove
+        ev.accept()
 
     def hoverEvent(self, ev):
         if (not ev.isExit()) and ev.acceptDrags(QtCore.Qt.LeftButton):


### PR DESCRIPTION
Add call to ev.accept() in Tick.mouseClickEvent to prevent parent menu from opening on a right click of a Tick.